### PR TITLE
Close #1: Load images on demand

### DIFF
--- a/classes/MainCommand.php
+++ b/classes/MainCommand.php
@@ -62,6 +62,9 @@ class MainCommand
                     ? "position: static; display: block; z-index: 1; width: 100%"
                     : "position: absolute; display: none; width: 100%";
             },
+            'loading' => /** @param int $i */ function ($i) {
+                return $i === 0 ? "eager" : "lazy";
+            },
             'option' => /** @param string $name */ function ($name) use ($opts) {
                 return $opts[$name];
             }

--- a/views/slideshow.php
+++ b/views/slideshow.php
@@ -14,7 +14,7 @@ if (!isset($this)) {
 <?php   if ($img->hasWebp()):?>
         <source srcset="<?=$this->escape($img->getWebp())?>" type="image/webp">
 <?php   endif?>
-        <img src="<?=$this->escape($img->getFilename())?>" alt="<?=$this->escape($img->getName())?>">
+        <img src="<?=$this->escape($img->getFilename())?>" alt="<?=$this->escape($img->getName())?>" loading="<?=$this->loading($i)?>">
     </picture>
 <?php endforeach?>
 </div>


### PR DESCRIPTION
This is the most simplistic implementation we can think of, but it also
might the most effective: we use the `loading` attribute of the `img`
element to load the first slide show image `eager`, but all others
`lazy`.  This should be sufficient to cover all of the alternative
`picture` `source`s.  Of course, the effect heavily depends on browser
support.